### PR TITLE
fix: add scripts, update for slim, better naming

### DIFF
--- a/Dockerfile-node-6-slim
+++ b/Dockerfile-node-6-slim
@@ -1,7 +1,0 @@
-FROM node:6.14.1-slim
-
-RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list
-
-RUN apt-get update
-RUN apt-get install -y firewalld beep
-RUN apt-get install -y imagemagick

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Docker Goof
 
-Open a terminal and open the `docker-goof` directory.
+Open a terminal at the `docker-goof` directory.
 
 1. Build the image
 
@@ -22,6 +22,20 @@ cd docker-goof && \
 docker build -t docker-goof . && \
 snyk test --docker docker-goof --file=Dockerfile
 ```
+
+###Utility scripts
+
+To build all images:
+
+   ```console
+   ./build.sh
+   ```
+
+To test all images:
+
+   ```console
+   ./test.sh
+   ```
 
 ## Screenshots
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+pushd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )" >/dev/null
+
+for f in $(ls *Dockerfile); do
+  base=$(basename ${f})
+  flavour=${base%.Dockerfile}
+  flavour=${flavour%Dockerfile}
+  tag=docker-goof${flavour:+-$flavour}
+  file=${flavour:+-f $base}
+  echo Building ${tag}...
+  docker build -q -t ${tag} . ${file}
+done
+
+popd >/dev/null

--- a/n6-slim-fw.Dockerfile
+++ b/n6-slim-fw.Dockerfile
@@ -1,0 +1,5 @@
+FROM node:6.14.1-slim
+
+RUN apt-get update
+RUN apt-get install -y firewalld beep
+RUN apt-get install -y imagemagick

--- a/n6-slim.Dockerfile
+++ b/n6-slim.Dockerfile
@@ -1,0 +1,4 @@
+FROM node:6.14.2-slim
+ 
+RUN apt-get update -y
+RUN apt-get install -y imagemagick

--- a/slim.Dockerfile
+++ b/slim.Dockerfile
@@ -1,3 +1,4 @@
 FROM node:10.4.0-slim
 
+RUN apt-get update
 RUN apt-get install -y imagemagick

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+pushd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )" >/dev/null
+
+for f in $(ls *Dockerfile); do
+  base=$(basename ${f})
+  flavour=${base%.Dockerfile}
+  flavour=${flavour%Dockerfile}
+  tag=docker-goof${flavour:+-$flavour}
+  echo Testing ${tag}...
+  snyk test --docker ${tag} --file=${base}
+done
+
+popd >/dev/null

--- a/wp.Dockerfile
+++ b/wp.Dockerfile
@@ -1,3 +1,4 @@
 FROM wordpress:5
 
+RUN apt-get update
 RUN apt-get install -y imagemagick


### PR DESCRIPTION

- add `build.sh` and `test.sh` utility scripts
- run `apt-get update` before `apt-get install` for slim images
- use the more recognized `<purpose>.Dockerfile` form for naming